### PR TITLE
Fix missing model summary call

### DIFF
--- a/price_prediction.ipynb
+++ b/price_prediction.ipynb
@@ -1138,7 +1138,7 @@
     "model.add(keras.layers.Dense(32)) \n",
     "model.add(keras.layers.Dropout(0.5)) \n",
     "model.add(keras.layers.Dense(1)) \n",
-    "model.summary \n"
+    "model.summary() \n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- fix bug that skipped printing the model summary by calling `model.summary()`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685130c4426c8322bd3427f14adc37cd