### PR TITLE
Improve LSTM model and data path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Data Preprocessing
 
 The code starts by installing the necessary libraries, including TensorFlow, Pandas, and Matplotlib.
 It then reads in a CSV file containing stock data, likely historical stock prices and related features.
+Set the `STOCK_CSV` environment variable to the path of the `all_stocks_5yr.csv` file before running the script.
 The data is preprocessed by converting the 'date' column to a datetime format and scaling the 'close' prices using the MinMaxScaler from scikit-learn.
 The scaled data is then split into training and testing sets, with the training set comprising 95% of the data.
 The training data is further processed by creating input features (x_train) and labels (y_train) using a sliding window approach. This is a common technique for preparing time series data for sequence prediction tasks.
@@ -12,8 +13,8 @@ The training data is further processed by creating input features (x_train) and 
 Model Architecture
 
 The code defines a Sequential model in Keras, which is a popular deep learning library.
-The model consists of two LSTM (Long Short-Term Memory) layers, each with 64 units. LSTM is a type of recurrent neural network (RNN) that is well-suited for handling sequential data, such as time series.
-After the LSTM layers, the model has a Dense layer with 32 units, followed by a Dropout layer with a rate of 0.5 to prevent overfitting.
+The improved model stacks three LSTM layers with 128, 128, and 64 units respectively.
+After the LSTM layers, the model includes a Dense layer with 64 units and a Dropout layer with a rate of 0.5 to reduce overfitting.
 The final layer is a Dense layer with a single unit, which is used for the regression task of predicting stock prices.
 
 Model Training and Evaluation

--- a/code
+++ b/code
@@ -13,7 +13,8 @@ import warnings
 warnings.filterwarnings("ignore") 
 
 # Path to CSV file
-data = pd.read_csv(r"C:\Users\admin\Downloads\all_stocks_5yr.csv")
+DATA_PATH = os.getenv("STOCK_CSV", "all_stocks_5yr.csv")
+data = pd.read_csv(DATA_PATH)
 print(data.shape) 
 print(data.sample(7)) 
 data.info()
@@ -65,24 +66,25 @@ for i in range(60, len(train_data)):
 x_train, y_train = np.array(x_train), np.array(y_train) 
 x_train = np.reshape(x_train, (x_train.shape[0], x_train.shape[1], 1)) 
 
-model = keras.models.Sequential()
-model.add(keras.layers.LSTM(units=128,
-                            return_sequences=True,
-                            input_shape=(x_train.shape[1], 1)))
-model.add(keras.layers.LSTM(units=64))
-model.add(keras.layers.Dense(32, activation='relu'))
-model.add(keras.layers.Dropout(0.2))
-model.add(keras.layers.Dense(1))
+model = keras.models.Sequential([
+    keras.layers.LSTM(128, return_sequences=True,
+                      input_shape=(x_train.shape[1], 1)),
+    keras.layers.LSTM(128, return_sequences=True),
+    keras.layers.LSTM(64),
+    keras.layers.Dense(64, activation='relu'),
+    keras.layers.Dropout(0.5),
+    keras.layers.Dense(1)
+])
 model.summary()
 
-model.compile(optimizer='adam',
+model.compile(optimizer=keras.optimizers.Adam(learning_rate=0.001),
                         loss='mean_squared_error')
 early_stop = keras.callbacks.EarlyStopping(monitor='val_loss',
-                                           patience=3,
+                                           patience=10,
                                            restore_best_weights=True)
 history = model.fit(x_train,
                                         y_train,
-                                        epochs=50,
+                                        epochs=100,
                                         validation_split=0.1,
                                         callbacks=[early_stop])
 
@@ -113,7 +115,8 @@ test['Predictions'] = predictions
 plt.figure(figsize=(10, 8)) 
 plt.plot(train['date'], train['close']) 
 plt.plot(test['date'], test[['close', 'Predictions']]) 
-plt.title('Apple Stock Close Price') 
-plt.xlabel('Date') 
-plt.ylabel("Close") 
-plt.legend(['Train', 'Test', 'Predictions']) 
+plt.title('Apple Stock Close Price')
+plt.xlabel('Date')
+plt.ylabel("Close")
+plt.legend(['Train', 'Test', 'Predictions'])
+plt.show()


### PR DESCRIPTION
## Summary
- configure data path via `STOCK_CSV` env var
- build deeper LSTM model with heavier dropout
- train for more epochs with patience
- show prediction plot
- document improvements in README

## Testing
- `python -m py_compile code`


------
https://chatgpt.com/codex/tasks/task_b_6851389067d0832288fbfdb099355d95