### PR TITLE
Add MAPE accuracy metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ Compiling the model with appropriate loss function and optimizer.
 Training the model on the x_train and y_train data.
 Evaluating the model's performance on the test set (x_test and y_test).
 Potentially fine-tuning the model hyperparameters or architecture based on the evaluation results.
+
+The script also calculates the Mean Absolute Percentage Error (MAPE) and an accuracy percentage defined as `100 - MAPE`.

--- a/code
+++ b/code
@@ -108,6 +108,12 @@ print("RMSE", np.sqrt(mse))
 r2 = r2_score(y_test, predictions)
 print("R2 Score", r2)
 
+# calculate Mean Absolute Percentage Error (MAPE)
+mape = np.mean(np.abs((y_test - predictions) / y_test)) * 100
+accuracy = 100 - mape
+print("MAPE", mape)
+print("Accuracy (%)", accuracy)
+
 train = apple[:training] 
 test = apple[training:] 
 test['Predictions'] = predictions 


### PR DESCRIPTION
## Summary
- calculate mean absolute percentage error in the training script
- output an accuracy percentage based on MAPE
- document the new metric in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68513e0650488322b20caf92b2bac0c3